### PR TITLE
fixed CMIP5 model names and bug with log permissions

### DIFF
--- a/clef/cli.py
+++ b/clef/cli.py
@@ -82,7 +82,10 @@ def config_log():
     month = datetime.now().strftime("%Y%m") 
     logname = '/g/data/ua8/Download/CMIP6/clef_log_' + month + '.txt' 
     flog = logging.FileHandler(logname) 
-    os.chmod(logname, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO);
+    try:
+        os.chmod(logname, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO);
+    except:
+        pass 
     flog.setLevel(logging.INFO)
     flog.setFormatter(formatter)
     logger.addHandler(flog)

--- a/clef/code.py
+++ b/clef/code.py
@@ -259,6 +259,6 @@ def call_local_query(s, project, oformat, **kwargs):
     return paths
 
 def combined(path):
-    ''' get path from table and converte output dirs to combined '''
+    ''' get path from table and convert output dirs to combined '''
     pdir = os.path.dirname(path)
-    return re.sub(r'\/output[12]\/','/combined/',pdir)
+    return re.sub(r'\/output[12]?\/','/combined/',pdir)

--- a/clef/data/CMIP5_model_fix.json
+++ b/clef/data/CMIP5_model_fix.json
@@ -1,16 +1,9 @@
 {
     "ACCESS1.0": "ACCESS1-0", 
     "ACCESS1.3": "ACCESS1-3", 
-    "CESM1(BGC)": "CESM1-BGC", 
-    "CESM1(CAM5)": "CESM1-CAM5", 
-    "CESM1(CAM5.1,FV2)": "CESM1-CAM5-1-FV2", 
-    "CESM1(FASTCHEM)": "CESM1-FASTCHEM", 
-    "CESM1(WACCM)": "CESM1-WACCM", 
+    "CESM1(CAM5.1,FV2)": "CESM1-CAM5.1-FV2",
+    "CESM1(FASTCHEM)": "CESM1-FASTCHEM",
     "CSIRO-Mk3.6.0": "CSIRO-Mk3-6-0", 
     "GFDL-CM2.1": "GFDL-CM2p1", 
-    "MRI-AGCM3.2H": "MRI-AGCM3-2H", 
-    "MRI-AGCM3.2S": "MRI-AGCM3-2S", 
-    "BCC-CSM1.1": "bcc-csm1-1", 
-    "BCC-CSM1.1(m)": "bcc-csm1-1-m", 
     "INM-CM4": "inmcm4"
 }

--- a/clef/data/CMIP5_validation.json
+++ b/clef/data/CMIP5_validation.json
@@ -22,6 +22,7 @@
 "CanCM4",
 "CanESM2",
 "EC-EARTH",
+"EC-EARTH-2-2",
 "FGOALS-g2",
 "FGOALS-gl",
 "FGOALS-s2",
@@ -59,7 +60,9 @@
 "MRI-ESM1",
 "NICAM-09",
 "NorESM1-M",
-"NorESM1-ME"
+"NorESM1-ME",
+"COSMOS-ASO",
+"KCM1-2-2"
 ],
 "variables": [
 "abs550aer",
@@ -314,7 +317,9 @@
 "hfrainds",
 "hfrunoffds",
 "hfsifrazil",
+"hfsifrazil2d",
 "hfsithermds",
+"hfsithermds2d",
 "hfsnthermds",
 "hfss",
 "hfssClim",


### PR DESCRIPTION
The current attempt to manage log file permissions in cli, was causing issues because only the file owner can change them, I put it in a try: except: pass  so if it fails the code just go on