### PR TITLE
removed ipython3 from rst files code::

### DIFF
--- a/docs/training2.rst
+++ b/docs/training2.rst
@@ -1,7 +1,7 @@
 CORDEX
 ------
 
-.. code:: ipython3
+.. code::
 
     !clef cordex --help
 
@@ -78,7 +78,7 @@ its experiment design. These are the cordex ``domain``, ``rcm_name``,
 tables so you always have to use f\ ``--frequency`` to select different
 timesteps.
 
-.. code:: ipython3
+.. code::
 
     !clef cordex -v tas -e historical -dmod CSIRO-BOM-ACCESS1-3 -en r1i1p1 -f mon
 
@@ -98,7 +98,7 @@ timesteps.
 CMIP6
 -----
 
-.. code:: ipython3
+.. code::
 
     !clef cmip6 --help
 
@@ -181,7 +181,7 @@ approximation of the actual resolution and **grid**.
 Controlling the ouput: clef options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: ipython3
+.. code::
 
     !clef --local cmip6 -e 1pctCO2 -t Amon -v tasmax -v tasmin -g gr
 
@@ -213,7 +213,7 @@ same, whichever way we perform the query. This way of searching can give
 you more results if a node is offline or if a version have been
 unpublished from the ESGF but is still available locally.
 
-.. code:: ipython3
+.. code::
 
     !clef --missing cmip6 -e 1pctCO2 -v clw -v clwvi -t Amon -g gr
 
@@ -234,7 +234,7 @@ the results matching the constraints that are available on the ESGF but
 not locally (we changed variables to make sure to get some missing data
 back).
 
-.. code:: ipython3
+.. code::
 
     !clef --remote cmip6 -e 1pctCO2 -v tasmin -t Amon -g gr
 
@@ -308,7 +308,7 @@ With anything else or if you don’t pass anything it will assume you
 don’t want to put in a request. It still saved the request in a file we
 can use later.
 
-.. code:: ipython3
+.. code::
 
     !head -n 4 CMIP6_*.txt
 

--- a/docs/training3.rst
+++ b/docs/training3.rst
@@ -9,7 +9,7 @@ first to import some functions from the clef.code sub-module. In
 particular the **search( )** function and **connect( )** and **Session(
 )** that we’ll use to open a connection to the database.
 
-.. code:: ipython3
+.. code::
 
     from clef.code import *
     db = connect()
@@ -25,7 +25,7 @@ project=‘CMIP5’, latest=True, \**kwargs)
 
 Let’s start by defining some constraints.
 
-.. code:: ipython3
+.. code::
 
     constraints = {'variable': 'tas', 'model': 'MIROC5', 'cmor_table': 'day', 'experiment': 'rcp85'}
 
@@ -34,7 +34,7 @@ attributes stored by the database. You can use any of the *facets* used
 for ESGF but in future we will be adding other options based on extra
 fields which are stored as attributes.
 
-.. code:: ipython3
+.. code::
 
     results = search(s, project='CMIP5', **constraints)
     results
@@ -207,7 +207,7 @@ value that doesn’t exist for the chosen project, the function will print
 a list of valid values and then exit. Let’s rewrite the constraints
 dictionary to show an example.
 
-.. code:: ipython3
+.. code::
 
     constraints = {'v': 'tas', 'm': 'MIROC5', 'table': 'day', 'experiment': 'rcp85', 'activity': 'CMIP'}
     results = search(s, **constraints)
@@ -252,7 +252,7 @@ that can be used for each key. The full list of valid keys is available
 from from the github repository:
 https://github.com/coecms/clef/blob/master/clef/data/valid_keys.json
 
-.. code:: ipython3
+.. code::
 
     constraints = {'v': 'tas', 'm': 'MIROC5', 'table': 'day', 'experiment': 'rcp85', 'member': 'r1i1p1'}
     results = search(s, **constraints)
@@ -301,7 +301,7 @@ that we are passing list of values instead of strings:
 
 Let’s look at an example:
 
-.. code:: ipython3
+.. code::
 
     constraints = {'variable': ['tasmin','tasmax'], 'model': ['MIROC5','MIROC4h'],
                    'cmor_table': ['day'], 'experiment': ['rcp85'], 'ensemble': ['r1i1p1']}

--- a/docs/training4.rst
+++ b/docs/training4.rst
@@ -17,7 +17,7 @@ values to be present, only ``variable_id`` in this case. Finally we tell
 the function which attributes define a simulation, this would most often
 be ``model`` and ``member``.
 
-.. code:: ipython3
+.. code::
 
     constraints = {'variable_id': ['pr','mrso'], 'frequency': ['mon'], 'experiment_id': ['historical']}
     allvalues = ['variable_id']
@@ -32,7 +32,7 @@ names. You can see by printing the length of both lists and one of the
 first item of *selection* that the results have been grouped by
 models/ensembles and then filtered.
 
-.. code:: ipython3
+.. code::
 
     print(len(results),len(selection))
     selection.iloc[0,:]
@@ -69,7 +69,7 @@ AND filter on more than one attribute
 We can pass more than value for more than one attribute, let’s add
 *piControl* to the experiment list.
 
-.. code:: ipython3
+.. code::
 
     constraints = {'variable_id': ['pr','mrso'], 'frequency': ['mon'], 'experiment_id': ['historical', 'piControl']}
     results, selection = matching(s, allvalues, fixed, project='CMIP6', **constraints)
@@ -100,7 +100,7 @@ included experiment and the results for the two experiments are grouped
 together, to fix this we need to add ``experiment_id`` to the *fixed*
 list.
 
-.. code:: ipython3
+.. code::
 
     fixed = ['source_id', 'member_id','experiment_id']
     results, selection = matching(s, allvalues, fixed, project='CMIP6', **constraints)
@@ -127,7 +127,7 @@ If we wanted to find all models/members combinations which have both
 variables and both experiments, then we should have kept *fixed* as it
 was and add ``experiment_id`` to the *allvalues* list instead.
 
-.. code:: ipython3
+.. code::
 
     allvalues = ['variable_id', 'experiment_id']
     fixed=['source_id','member_id']
@@ -161,7 +161,7 @@ to perfom this query directly on the local database if you want you can
 perform the same query on the ESGF database, so you can see what has
 been published.
 
-.. code:: ipython3
+.. code::
 
     constraints = {'variable': ['tasmin','tasmax'], 'cmor_table': ['Amon'], 'experiment': ['historical','rcp26', 'rcp85']}
     allvalues = ['variable', 'experiment']
@@ -199,7 +199,7 @@ the flag can be used more than once. By default model/ensemble
 combinations define a simulation, and only model, ensemble and version
 are returned as final result.
 
-.. code:: ipython3
+.. code::
 
     !clef --local cmip5 -v tasmin -v tasmax -e rcp26 -e rcp85 -e historical -t Amon --and variable
 
@@ -223,7 +223,7 @@ are returned as final result.
 
 The same will work for ``--remote`` and *cmip6*
 
-.. code:: ipython3
+.. code::
 
     !clef --remote cmip6 -v pr -v mrso -e piControl  -mi r1i1p1f1 --frequency mon --and variable_id
 

--- a/docs/training5.rst
+++ b/docs/training5.rst
@@ -10,7 +10,7 @@ list all the available attributes. This currently works only with the
 ``--local`` and ``--remote`` option, it doesn’t yet work for the
 standard search, which is basically a combination of the two.
 
-.. code:: ipython3
+.. code::
 
     !clef --local cmip5 -v pr -v tas -e piControl  -en r1i1p1 -t Amon --csv
 
@@ -25,7 +25,7 @@ standard search, which is basically a combination of the two.
     Saving to CMIP5_query.csv
 
 
-.. code:: ipython3
+.. code::
 
     !head -n 4 CMIP5_query.csv
 
@@ -44,7 +44,7 @@ following example demonstrate how ``--csv`` works also for remote CMIP6
 queries and with the flag ``--and`` which allows for more complex
 filtering of the data and that we haven’t looked at yet.
 
-.. code:: ipython3
+.. code::
 
     !clef --remote cmip6 -v pr -v mrso -e piControl  -mi r1i1p1f1 --frequency mon --and variable_id --csv
 
@@ -60,7 +60,7 @@ filtering of the data and that we haven’t looked at yet.
     TaiESM1 / r1i1p1f1 versions: v20200302, v20200211
     Saving to CMIP6_query.csv
 
-.. code:: ipython3
+.. code::
 
     !head -n 4 CMIP6_query.csv
 
@@ -82,7 +82,7 @@ following: \* total number of models, followed by their names \* total
 number of unique model-ensembles/members combinations \* number of
 models that have N ensembles/members, followed by their names
 
-.. code:: ipython3
+.. code::
 
     !clef --local cmip5 -v pr -e rcp85 -t Amon --stats
 
@@ -150,7 +150,7 @@ use them after having retrieve the tracking_id attribute in another way
 (for example with a simple nc_dump or via xarray if in python). Let’s
 start from the errata:
 
-.. code:: ipython3
+.. code::
 
     from clef.esdoc import *
     tracking_id = 'hdl:21.14100/a2c2f719-6790-484b-9f66-392e62cd0eb8'
@@ -176,7 +176,7 @@ then prints it in a human readable form, including the url for the
 original error report. Let’s now have a look at how to retrieve and
 print some documentation from ESDOC.
 
-.. code:: ipython3
+.. code::
 
     doc_url = get_doc(dtype='model', name='MIROC6', project='CMIP6')
 
@@ -203,7 +203,7 @@ retrieve the document, by default this is CMIP6. It will retrieve the
 document online and print out a summary. It will also return the url for
 the full document report, shown below.
 
-.. code:: ipython3
+.. code::
 
     print(doc_url)
 
@@ -218,7 +218,7 @@ CMIP5, the **get_wdcc()** function access these documents. In this case
 rather than the type of document you have to use the dataset_id to
 retrieve the information.
 
-.. code:: ipython3
+.. code::
 
     doc_url, response = get_wdcc('cmip5.output1.MIROC.MIROC5.historical.mon.atmos.Amon.r1i1p1.v20111028')
     print(doc_url)

--- a/docs/training6.rst
+++ b/docs/training6.rst
@@ -13,7 +13,7 @@ Let’s look at an example, if I want to get all the rcps experiments and
 historical I might be tempted to pass them as constraints in the same
 query:
 
-.. code:: ipython3
+.. code::
 
     !clef cmip5 -m CMCC-CM -e historical --experiment_family RCP -t Omon -v tos -en r1i1p1
 
@@ -28,7 +28,7 @@ We couldn’t find any matches because both the ``experiment`` and
 pass rcp45 as experiment as well as the family RCP we will only get the
 rcp45 results.
 
-.. code:: ipython3
+.. code::
 
     !clef cmip5 -m CMCC-CM -e rcp45 --experiment_family RCP -t Omon -v tos -en r1i1p1
 
@@ -43,7 +43,7 @@ rcp45 results.
 Finally, it is now possible to use ``experiment_family`` also in the
 local search:
 
-.. code:: ipython3
+.. code::
 
     !clef --local cmip5 -m CMCC-CM --experiment_family RCP -t Omon -v tos -en r1i1p1
 
@@ -71,7 +71,7 @@ information only for CMIP6, so this flag is only available with the
 **cmip6** sub-command. As for the other flags illustrated above, this
 option works when you select either ``--local`` or ``--remote`` queries.
 
-.. code:: ipython3
+.. code::
 
     !clef --remote cmip6 -v clt  -e historical -t day  -mi r1i1p1f1 --cite
 
@@ -89,7 +89,7 @@ option works when you select either ``--local`` or ``--remote`` queries.
 The citations are listed in a cmip_citations.txt file in the current
 directory.
 
-.. code:: ipython3
+.. code::
 
     ! head -n 4 cmip_citations.txt 
 
@@ -109,123 +109,3 @@ these fields are not available the citation might be incomplete, so
 always check the entire file before using it. In particular the part of
 the citation that includes the doi will be missing.
 
-Searching for other climate datasets: ds
-----------------------------------------
-
-Let’s get back to the command line now and have a look at the third
-command **ds**\  This command let you query a separate database that
-contains information on other climate datasets which are available on
-raijin.
-
-.. code:: ipython3
-
-    !clef ds --help
-
-
-.. parsed-literal::
-
-    Usage: clef ds [OPTIONS]
-    
-      Search local database for non-ESGF datasets
-    
-    Options:
-      -d, --dataset TEXT              Dataset name
-      -v, --version TEXT              Dataset version
-      -f, --format [netcdf|grib|HDF5|binary]
-                                      Dataset file format as defined in clef.db
-                                      Dataset table
-    
-      -sn, --standard-name [air_temperature|air_pressure|rainfall_rate]
-                                      Variable standard_name this is the most
-                                      reliable way to look for a variable across
-                                      datasets
-    
-      -cn, --cmor-name [ps|pres|psl|tas|ta|pr|tos]
-                                      Variable cmor_name useful to look for a
-                                      variable across datasets
-    
-      -va, --variable [T|U|V|Z]       Variable name as defined in files: tas, pr,
-                                      sic, T ...
-    
-      --frequency [yr|mon|day|6hr|3hr|1hr]
-                                      Time frequency on which variable is defined
-      --from-date TEXT                To define a time range of availability of a
-                                      variable, can be used on its own or together
-                                      with to-date. Format is YYYYMMDD
-    
-      --to-date TEXT                  To define a time range of availability of a
-                                      variable, can be used on its own or together
-                                      with from-date. Format is YYYYMMDD
-    
-      --help                          Show this message and exit.
-
-
-| clef ds
-| with no other argument will return a list of the local datasets
-  available in the database. NB this is not an exhaustive list of the
-  climate collections at NCI and not all the datasets already in the
-  database have been completed.
-
-.. code:: ipython3
-
-    !clef ds
-
-
-.. parsed-literal::
-
-    ERA5 v1.0: /g/data/ub4/era5/netcdf/<stream>/<varname>/<year>/
-    MACC v1.0: /g/data/ub4/macc/grib/<stream>/
-    YOTC v1.0: /g/data/rq7/yotc
-    ERAI v1.0: /g/data/ub4/erai/netcdf/<frequency>/<realm>/<stream>/<version>/<varname>/
-    OSTIA vNA: /g/data/ua8/ostia
-    TRMM_3B42 v7: /g/data/ua8/NASA_TRMM/TRMM_L3/TRMM_3B42/<YYYY>/
-    OISST v2.0: /g/data/ua8/NOAA_OISST/AVHRR/v2-0_modified/
-    MERRA2 v5.12.4: /g/data/rr7/MERRA2/raw/<streamv1>.<version>/<YYYY>/<MM>/
-    ERAI v1.0: /g/data/ub4/erai/netcdf/<frequency>/<realm>/<stream>/v01/<varname>/
-    MACC v1.0: /g/data/ub4/macc/netcdf/<frequency>/<realm>/<stream>/v01/<varname>/
-    YOTC v1.0: /g/data/rq7/yotc
-
-
-If you specify any of the variable options then the query will return a
-list of variables rather then datasets. Since variables can be named
-differently among datasets, using the *standard_name* or *cmor_name*
-options to identify them is the best option.
-
-.. code:: ipython3
-
-    !clef ds -f netcdf --standard-name air_temperature
-
-
-.. parsed-literal::
-
-    2T: /g/data/ub4/era5/netcdf/surface/2T/<year>/2T_era5_-90 90 -180 179.75_<YYYYMMDD>_<YYYYMMDD>.nc
-    T: /g/data/ub4/era5/netcdf/pressure/T/<year>/T_era5_-57 20 78 -140_<YYYYMMDD>_<YYYYMMDD>.nc
-    2T: /g/data/ub4/era5/netcdf/surface/2T/<year>/2T_era5_-90 90 -180 179.75_<YYYYMMDD>_<YYYYMMDD>.nc
-    T: /g/data/ub4/era5/netcdf/pressure/T/<year>/T_era5_-57 20 78 -140_<YYYYMMDD>_<YYYYMMDD>.nc
-    ta: /g/data/ub4/erai/netcdf/6hr/atmos/oper_an_pl/1.0/ta/ta_6hr_ERAI_historical_oper_an_pl_<YYYYMMDD>_<YYYYMMDD>.nc
-    tas: /g/data/ub4/erai/netcdf/6hr/atmos/oper_an_sfc/1.0/tas/tas_6hr_ERAI_historical_oper_an_sfc_<YYYYMMDD>_<YYYYMMDD>.nc
-    ta: /g/data/ub4/erai/netcdf/6hr/atmos/oper_an_ml/1.0/ta/ta_6hr_ERAI_historical_oper_an_ml_<YYYYMMDD>_<YYYYMMDD>.nc
-    mn2t: /g/data/ub4/erai/netcdf/3hr/atmos/oper_fc_sfc/1.0/mn2t/mn2t_3hr_ERAI_historical_oper_fc_sfc_<YYYYMMDD>_<YYYYMMDD>.nc
-    mx2t: /g/data/ub4/erai/netcdf/3hr/atmos/oper_fc_sfc/1.0/mx2t/mx2t_3hr_ERAI_historical_oper_fc_sfc_<YYYYMMDD>_<YYYYMMDD>.nc
-    tas: /g/data/ub4/erai/netcdf/3hr/atmos/oper_fc_sfc/1.0/tas/tas_3hr_ERAI_historical_oper_fc_sfc_<YYYYMMDD>_<YYYYMMDD>.nc
-
-
-This returns all the variable available as netcdf files and with
-air_temperature as standard_name. NB for each variable a path structure
-is returned.
-
-.. code:: ipython3
-
-    !clef ds -f netcdf --cmor-name ta
-
-
-.. parsed-literal::
-
-    T: /g/data/ub4/era5/netcdf/pressure/T/<year>/T_era5_-57 20 78 -140_<YYYYMMDD>_<YYYYMMDD>.nc
-    T: /g/data/ub4/era5/netcdf/pressure/T/<year>/T_era5_-57 20 78 -140_<YYYYMMDD>_<YYYYMMDD>.nc
-    ta: /g/data/ub4/erai/netcdf/6hr/atmos/oper_an_pl/1.0/ta/ta_6hr_ERAI_historical_oper_an_pl_<YYYYMMDD>_<YYYYMMDD>.nc
-    ta: /g/data/ub4/erai/netcdf/6hr/atmos/oper_an_ml/1.0/ta/ta_6hr_ERAI_historical_oper_an_ml_<YYYYMMDD>_<YYYYMMDD>.nc
-
-
-This returns a subset of the previous query using the cmor_name to
-clearly identify one kind of air_temperature.


### PR DESCRIPTION
Changing "code:: ipython3" to. "code::" to show commands in docs